### PR TITLE
Hotfix for null data exception on back button

### DIFF
--- a/affirm/src/main/java/com/affirm/android/Affirm.java
+++ b/affirm/src/main/java/com/affirm/android/Affirm.java
@@ -593,6 +593,13 @@ public final class Affirm {
 
                         callbacks.onAffirmVcnCheckoutCancelled();
                     } else {
+
+                        if(data==null) {
+                            data = new Intent();
+                            VcnReason reason = VcnReason.builder().setReason("canceled").build();
+                            data.putExtra(VCN_REASON, reason);
+                        }
+
                         callbacks.onAffirmVcnCheckoutCancelledReason(
                                 (VcnReason) data.getParcelableExtra(VCN_REASON));
                     }


### PR DESCRIPTION
Nullpointer exception when a user clicks the android back button. We needed to hardcode a reason code for that edge case since it's not triggered from the browser event (or submitted the consoleMessage).