### PR TITLE
shipping & billing object improvement

### DIFF
--- a/affirm/src/main/java/com/affirm/android/Affirm.java
+++ b/affirm/src/main/java/com/affirm/android/Affirm.java
@@ -460,9 +460,6 @@ public final class Affirm {
                                      boolean useVCN) {
         AffirmUtils.requireNonNull(activity, "activity cannot be null");
         AffirmUtils.requireNonNull(checkout, "checkout cannot be null");
-        if (checkout.isSendBillingAndShippingAddresses() && checkout.shipping() == null) {
-            AffirmUtils.requireNonNull(checkout.shipping(), "shipping cannot be null");
-        }
         if (useVCN) {
             VcnCheckoutActivity.startActivity(
                     activity, vcnCheckoutRequest, checkout, receiveReasonCodes);

--- a/affirm/src/main/java/com/affirm/android/AffirmUtils.java
+++ b/affirm/src/main/java/com/affirm/android/AffirmUtils.java
@@ -113,13 +113,13 @@ public final class AffirmUtils {
         return null;
     }
 
-    static <T> void requireNonNull(T obj) {
+    public static <T> void requireNonNull(T obj) {
         if (obj == null) {
             throw new NullPointerException();
         }
     }
 
-    static <T> void requireNonNull(T obj, String message) {
+    public static <T> void requireNonNull(T obj, String message) {
         if (obj == null) {
             throw new NullPointerException(message);
         }

--- a/affirm/src/main/java/com/affirm/android/model/Billing.java
+++ b/affirm/src/main/java/com/affirm/android/model/Billing.java
@@ -10,17 +10,19 @@ import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.SerializedName;
 
 @AutoValue
-public abstract class Shipping implements Parcelable {
+public abstract class Billing implements Parcelable {
     public static Builder builder() {
-        return new AutoValue_Shipping.Builder();
+        return new AutoValue_Billing.Builder();
     }
 
-    public static TypeAdapter<Shipping> typeAdapter(Gson gson) {
-        return new AutoValue_Shipping.GsonTypeAdapter(gson);
+    public static TypeAdapter<Billing> typeAdapter(Gson gson) {
+        return new AutoValue_Billing.GsonTypeAdapter(gson);
     }
 
+    @Nullable
     public abstract Address address();
 
+    @Nullable
     public abstract Name name();
 
     @Nullable
@@ -29,6 +31,7 @@ public abstract class Shipping implements Parcelable {
 
     @Nullable
     public abstract String email();
+
 
     @AutoValue.Builder
     public abstract static class Builder {
@@ -40,6 +43,6 @@ public abstract class Shipping implements Parcelable {
 
         public abstract Builder setEmail(String value);
 
-        public abstract Shipping build();
+        public abstract Billing build();
     }
 }

--- a/affirm/src/test/java/com/affirm/android/utils/CheckoutFactory.java
+++ b/affirm/src/test/java/com/affirm/android/utils/CheckoutFactory.java
@@ -1,6 +1,7 @@
 package com.affirm.android.utils;
 
 import com.affirm.android.model.Address;
+import com.affirm.android.model.Billing;
 import com.affirm.android.model.Checkout;
 import com.affirm.android.model.Item;
 import com.affirm.android.model.Name;
@@ -34,10 +35,11 @@ public class CheckoutFactory {
                 .build();
 
         final Shipping shipping = Shipping.builder().setAddress(address).setName(name).build();
+        final Billing billing = Billing.builder().setAddress(address).setName(name).build();
 
         return Checkout.builder()
                 .setItems(items)
-                .setBilling(shipping)
+                .setBilling(billing)
                 .setShipping(shipping)
                 .setShippingAmount(1000f)
                 .setTaxAmount(100f)

--- a/samples-java/src/main/java/com/affirm/samples/MainActivity.java
+++ b/samples-java/src/main/java/com/affirm/samples/MainActivity.java
@@ -19,6 +19,7 @@ import com.affirm.android.model.Address;
 import com.affirm.android.model.AffirmTrack;
 import com.affirm.android.model.AffirmTrackOrder;
 import com.affirm.android.model.AffirmTrackProduct;
+import com.affirm.android.model.Billing;
 import com.affirm.android.model.CardDetails;
 import com.affirm.android.model.Checkout;
 import com.affirm.android.model.Item;
@@ -196,11 +197,12 @@ public class MainActivity extends AppCompatActivity implements Affirm.CheckoutCa
                 .build();
 
         final Shipping shipping = Shipping.builder().setAddress(address).setName(name).build();
+        final Billing billing = Billing.builder().setAddress(address).setName(name).build();
 
         return Checkout.builder()
                 .setOrderId("55555")
                 .setItems(items)
-                .setBilling(shipping)
+                .setBilling(billing)
                 .setShipping(shipping)
                 .setShippingAmount(0f)
                 .setTaxAmount(100f)

--- a/samples-kotlin/src/main/java/com/affirm/sampleskt/MainActivity.kt
+++ b/samples-kotlin/src/main/java/com/affirm/sampleskt/MainActivity.kt
@@ -129,9 +129,11 @@ class MainActivity : AppCompatActivity(), Affirm.CheckoutCallbacks, Affirm.VcnCh
                 .setZipcode("94107")
                 .build()
         val shipping = Shipping.builder().setAddress(address).setName(name).build()
+        val billing = Billing.builder().setAddress(address).setName(name).build()
+
         return Checkout.builder()
                 .setItems(items)
-                .setBilling(shipping)
+                .setBilling(billing)
                 .setShipping(shipping)
                 .setShippingAmount(0f)
                 .setTaxAmount(100f)


### PR DESCRIPTION
1. Add `billing`, optional, and all of the parameters in the billing address should be optional
2. Add `phone_number`, `email` field on `billing` & `shipping` object
3. Add  parameter `sendShippingAddresses` (default true). Only when set `sendShippingAddresses` false, `shipping` object can be optional, otherwise it is required.