### PR TITLE
Fix more unnecessary ConnectionException and format exception message

### DIFF
--- a/affirm/src/test/java/com/affirm/android/CheckoutWebViewClientTest.java
+++ b/affirm/src/test/java/com/affirm/android/CheckoutWebViewClientTest.java
@@ -1,5 +1,6 @@
 package com.affirm.android;
 
+import android.os.Build;
 import android.webkit.WebResourceError;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
@@ -52,9 +53,15 @@ public class CheckoutWebViewClientTest {
     public void onReceivedError() {
         WebResourceRequest resourceRequest = Mockito.mock(WebResourceRequest.class);
         WebResourceError error = Mockito.mock(WebResourceError.class);
-        when(error.toString()).thenReturn("error msg");
+        when(error.getDescription()).thenReturn("error msg");
 
-        affirmWebViewClient.onReceivedError(webview, resourceRequest, error);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            affirmWebViewClient.onReceivedError(webview, resourceRequest, error);
+        } else {
+            affirmWebViewClient.onReceivedError(webview, error.getErrorCode(),
+                    error.getDescription() != null ? error.getDescription().toString() : "",
+                    resourceRequest.getUrl() != null ? resourceRequest.getUrl().toString() : "");
+        }
         Mockito.verify(callbacks, never()).onWebViewError(new ConnectionException("error msg"));
     }
 }

--- a/affirm/src/test/java/com/affirm/android/VcnCheckoutWebViewClientTest.java
+++ b/affirm/src/test/java/com/affirm/android/VcnCheckoutWebViewClientTest.java
@@ -1,5 +1,6 @@
 package com.affirm.android;
 
+import android.os.Build;
 import android.webkit.WebResourceError;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
@@ -81,7 +82,15 @@ public class VcnCheckoutWebViewClientTest {
     public void onReceivedError() {
         WebResourceRequest resourceRequest = Mockito.mock(WebResourceRequest.class);
         WebResourceError error = Mockito.mock(WebResourceError.class);
-        when(error.toString()).thenReturn("error msg");
+        when(error.getDescription()).thenReturn("error msg");
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            affirmWebViewClient.onReceivedError(webview, resourceRequest, error);
+        } else {
+            affirmWebViewClient.onReceivedError(webview, error.getErrorCode(),
+                    error.getDescription() != null ? error.getDescription().toString() : "",
+                    resourceRequest.getUrl() != null ? resourceRequest.getUrl().toString() : "");
+        }
 
         affirmWebViewClient.onReceivedError(webview, resourceRequest, error);
         Mockito.verify(callbacks, never()).onWebViewError(new ConnectionException("error msg"));


### PR DESCRIPTION
As the callback above 23 will be called for any resource (iframe, image, etc) that failed to load, not just for the main page