### PR TITLE
Fix the issue that AFFIRM_COLOR_TYPE_WHITE not work

### DIFF
--- a/affirm/src/main/java/com/affirm/android/AffirmColor.java
+++ b/affirm/src/main/java/com/affirm/android/AffirmColor.java
@@ -40,7 +40,7 @@ public enum AffirmColor {
             case AFFIRM_COLOR_TYPE_BLUE:
                 return R.color.affirm_blue;
             case AFFIRM_COLOR_TYPE_BLUE_BLACK:
-                return -1; // This is used for local style, no need to setColorFilter in this case
+                return 0; // This is used for local style, no need to setColorFilter in this case
             default:
                 return R.color.affirm_white;
         }

--- a/affirm/src/main/java/com/affirm/android/AffirmColor.java
+++ b/affirm/src/main/java/com/affirm/android/AffirmColor.java
@@ -38,9 +38,8 @@ public enum AffirmColor {
             case AFFIRM_COLOR_TYPE_BLACK:
                 return R.color.affirm_black;
             case AFFIRM_COLOR_TYPE_BLUE:
-                return R.color.affirm_blue;
             case AFFIRM_COLOR_TYPE_BLUE_BLACK:
-                return 0; // This is used for local style, no need to setColorFilter in this case
+                return R.color.affirm_blue;
             default:
                 return R.color.affirm_white;
         }

--- a/affirm/src/main/java/com/affirm/android/AffirmUtils.java
+++ b/affirm/src/main/java/com/affirm/android/AffirmUtils.java
@@ -27,6 +27,7 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.ContextCompat;
 
+import static com.affirm.android.AffirmColor.AFFIRM_COLOR_TYPE_BLUE_BLACK;
 import static com.affirm.android.AffirmConstants.LOGO_PLACEHOLDER;
 import static com.affirm.android.AffirmConstants.PLACEHOLDER_END;
 import static com.affirm.android.AffirmConstants.PLACEHOLDER_START;
@@ -140,25 +141,22 @@ public final class AffirmUtils {
             logoDrawable = resources.getDrawable(affirmLogoType.getDrawableRes(affirmColor));
         }
 
-        // The value 0 is an invalid identifier.
-        int color = affirmColor.getColorRes() != 0
-                ? resources.getColor(affirmColor.getColorRes()) : 0;
-
-        return getSpannable(template, textSize, logoDrawable, color);
+        return getSpannable(template, textSize, logoDrawable, affirmColor, resources);
     }
 
     private static SpannableString getSpannable(
             @NonNull String template,
             float textSize,
             @Nullable Drawable logoDrawable,
-            int color
+            @NonNull AffirmColor affirmColor,
+            @NonNull Resources resources
     ) {
         SpannableString spannableString;
 
         int index = template.indexOf(LOGO_PLACEHOLDER);
         if (logoDrawable != null && index != -1) {
             spannableString = new SpannableString(template);
-            ImageSpan imageSpan = getLogoSpan(textSize, logoDrawable, color);
+            ImageSpan imageSpan = getLogoSpan(textSize, logoDrawable, affirmColor, resources);
             spannableString.setSpan(
                     imageSpan,
                     index,
@@ -176,14 +174,17 @@ public final class AffirmUtils {
     private static ImageSpan getLogoSpan(
             float textSize,
             @NonNull Drawable logoDrawable,
-            int color
+            @NonNull AffirmColor affirmColor,
+            @NonNull Resources resources
     ) {
 
         float logoHeight = textSize * 1.f;
         float ratio = (float) logoDrawable.getIntrinsicWidth() / logoDrawable.getIntrinsicHeight();
 
-        if (color != 0) {
-            logoDrawable.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
+        // Should not setColorFilter for blue_black logo
+        if (affirmColor != AFFIRM_COLOR_TYPE_BLUE_BLACK) {
+            logoDrawable.setColorFilter(
+                    resources.getColor(affirmColor.getColorRes()), PorterDuff.Mode.SRC_ATOP);
         }
 
         logoDrawable.setBounds(0, 0,

--- a/affirm/src/main/java/com/affirm/android/AffirmUtils.java
+++ b/affirm/src/main/java/com/affirm/android/AffirmUtils.java
@@ -140,8 +140,9 @@ public final class AffirmUtils {
             logoDrawable = resources.getDrawable(affirmLogoType.getDrawableRes(affirmColor));
         }
 
-        int color = affirmColor.getColorRes() != -1
-                ? resources.getColor(affirmColor.getColorRes()) : -1;
+        // The value 0 is an invalid identifier.
+        int color = affirmColor.getColorRes() != 0
+                ? resources.getColor(affirmColor.getColorRes()) : 0;
 
         return getSpannable(template, textSize, logoDrawable, color);
     }
@@ -181,7 +182,7 @@ public final class AffirmUtils {
         float logoHeight = textSize * 1.f;
         float ratio = (float) logoDrawable.getIntrinsicWidth() / logoDrawable.getIntrinsicHeight();
 
-        if (color != -1) {
+        if (color != 0) {
             logoDrawable.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
         }
 


### PR DESCRIPTION
Found a isssue that AFFIRM_COLOR_TYPE_WHITE not work.
Because resources.getColor(R.color.white) will return -1, only the color_id = 0 is an invalid identifier.