### PR TITLE
Fix the drawable will changed the color because drawable is will shar…

### DIFF
--- a/affirm/src/main/java/com/affirm/android/AffirmUtils.java
+++ b/affirm/src/main/java/com/affirm/android/AffirmUtils.java
@@ -137,7 +137,7 @@ public final class AffirmUtils {
 
         Drawable logoDrawable = null;
         if (affirmLogoType != AFFIRM_DISPLAY_TYPE_TEXT) {
-            logoDrawable = resources.getDrawable(affirmLogoType.getDrawableRes(affirmColor));
+            logoDrawable = resources.getDrawable(affirmLogoType.getDrawableRes(affirmColor)).mutate();
         }
 
         int color = affirmColor.getColorRes() != -1


### PR DESCRIPTION
…e its state with any other drawable.

     * Make this drawable mutable. This operation cannot be reversed. A mutable
     * drawable is guaranteed to not share its state with any other drawable.
     * This is especially useful when you need to modify properties of drawables
     * loaded from resources. By default, all drawables instances loaded from
     * the same resource share a common state; if you modify the state of one
     * instance, all the other instances will receive the same modification.
     * Calling this method on a mutable Drawable will have no effect.