### PR TITLE
Fix affirm webview crash

### DIFF
--- a/affirm/src/main/java/com/affirm/android/Affirm.java
+++ b/affirm/src/main/java/com/affirm/android/Affirm.java
@@ -917,6 +917,7 @@ public final class Affirm {
             @Override
             public void onDestroy() {
                 affirmPromoRequest.cancel();
+                promotionButton.destroy();
             }
         };
 

--- a/affirm/src/main/java/com/affirm/android/AffirmActivity.java
+++ b/affirm/src/main/java/com/affirm/android/AffirmActivity.java
@@ -4,8 +4,6 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
-import android.view.ViewGroup;
-import android.webkit.WebView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -14,8 +12,7 @@ import androidx.fragment.app.Fragment;
 
 abstract class AffirmActivity extends AppCompatActivity implements AffirmWebChromeClient.Callbacks {
 
-    ViewGroup container;
-    WebView webView;
+    AffirmWebView webView;
     View progressIndicator;
 
     static void startForResult(@NonNull Activity originalActivity,
@@ -45,7 +42,6 @@ abstract class AffirmActivity extends AppCompatActivity implements AffirmWebChro
         super.onCreate(savedInstanceState);
 
         setContentView(R.layout.affirm_activity_webview);
-        container = getWindow().getDecorView().findViewById(android.R.id.content);
         webView = findViewById(R.id.webview);
         progressIndicator = findViewById(R.id.progressIndicator);
 
@@ -58,12 +54,7 @@ abstract class AffirmActivity extends AppCompatActivity implements AffirmWebChro
 
     @Override
     protected void onDestroy() {
-        container.removeView(webView);
-        webView.removeAllViews();
-        webView.clearCache(true);
-        webView.destroyDrawingCache();
-        webView.clearHistory();
-        webView.destroy();
+        webView.destroyWebView();
         webView = null;
         super.onDestroy();
     }

--- a/affirm/src/main/java/com/affirm/android/AffirmPromotionButton.java
+++ b/affirm/src/main/java/com/affirm/android/AffirmPromotionButton.java
@@ -28,6 +28,10 @@ public class AffirmPromotionButton extends FrameLayout {
     private String remoteCssUrl;
     private String typefaceDeclaration;
 
+    private float affirmTextSize;
+    private int affirmTextColor;
+    private int affirmTextFont;
+
     public AffirmPromotionButton(@NonNull Context context) {
         this(context, null);
     }
@@ -57,15 +61,15 @@ public class AffirmPromotionButton extends FrameLayout {
                 typedArray.getInt(R.styleable.AffirmPromotionButton_affirmColor,
                         AFFIRM_COLOR_TYPE_BLUE.getOrdinal());
 
-        float affirmTextSize =
+        affirmTextSize =
                 typedArray.getDimensionPixelSize(R.styleable.AffirmPromotionButton_affirmTextSize,
                         getResources().getDimensionPixelSize(R.dimen.affirm_promotion_size));
 
-        int affirmTextColor =
+        affirmTextColor =
                 typedArray.getResourceId(R.styleable.AffirmPromotionButton_affirmTextColor,
                         android.R.color.black);
 
-        int affirmTextFont =
+        affirmTextFont =
                 typedArray.getResourceId(R.styleable.AffirmPromotionButton_affirmTextFont,
                         0);
 
@@ -76,16 +80,6 @@ public class AffirmPromotionButton extends FrameLayout {
         affirmColor = AffirmColor.getAffirmColor(affirmColorOrdinal);
 
         typedArray.recycle();
-
-        promotionButton = new PromotionButton(context);
-        promotionButton.setAffirmTextSize(affirmTextSize);
-        promotionButton.setAffirmTextColor(affirmTextColor);
-        promotionButton.setTypeface(affirmTextFont > 0
-                ? ResourcesCompat.getFont(getContext(), affirmTextFont) : Typeface.DEFAULT);
-        promotionButton.setAffirmColor(affirmColor);
-        promotionButton.setAffirmLogoType(affirmLogoType);
-
-        promotionWebView = new PromotionWebView(context);
     }
 
     protected void setLabel(@NonNull String text) {
@@ -95,8 +89,21 @@ public class AffirmPromotionButton extends FrameLayout {
             addView(promotionWebView);
             promotionWebView.loadWebData(text, remoteCssUrl, typefaceDeclaration);
         } else {
+            buildPromotionButtonIfNeeded();
             addView(promotionButton);
             promotionButton.setText(promotionButton.updateSpan(text));
+        }
+    }
+
+    private void buildPromotionButtonIfNeeded() {
+        if (promotionButton == null) {
+            promotionButton = new PromotionButton(getContext());
+            promotionButton.setAffirmTextSize(affirmTextSize);
+            promotionButton.setAffirmTextColor(affirmTextColor);
+            promotionButton.setTypeface(affirmTextFont > 0
+                    ? ResourcesCompat.getFont(getContext(), affirmTextFont) : Typeface.DEFAULT);
+            promotionButton.setAffirmColor(affirmColor);
+            promotionButton.setAffirmLogoType(affirmLogoType);
         }
     }
 
@@ -107,12 +114,14 @@ public class AffirmPromotionButton extends FrameLayout {
     @Deprecated
     public void setAffirmLogoType(@NonNull AffirmLogoType affirmLogoType) {
         this.affirmLogoType = affirmLogoType;
+        buildPromotionButtonIfNeeded();
         promotionButton.setAffirmLogoType(affirmLogoType);
     }
 
     @Deprecated
     public void setAffirmColor(@NonNull AffirmColor affirmColor) {
         this.affirmColor = affirmColor;
+        buildPromotionButtonIfNeeded();
         promotionButton.setAffirmColor(affirmColor);
     }
 
@@ -137,6 +146,7 @@ public class AffirmPromotionButton extends FrameLayout {
         this.htmlStyling = true;
         this.remoteCssUrl = remoteCssUrl;
         this.typefaceDeclaration = typefaceDeclaration;
+        promotionWebView = new PromotionWebView(getContext());
     }
 
     public void configWithLocalStyling(@NonNull AffirmColor affirmColor,
@@ -177,6 +187,7 @@ public class AffirmPromotionButton extends FrameLayout {
         this.htmlStyling = false;
         this.affirmColor = affirmColor;
         this.affirmLogoType = affirmLogoType;
+        promotionButton = new PromotionButton(getContext());
         promotionButton.setAffirmColor(affirmColor);
         promotionButton.setAffirmLogoType(affirmLogoType);
         promotionButton.setTypeface(typeface);
@@ -200,8 +211,15 @@ public class AffirmPromotionButton extends FrameLayout {
     public void setOnClickListener(@Nullable OnClickListener l) {
         super.setOnClickListener(l);
 
-        if (htmlStyling) {
+        if (promotionWebView != null) {
             promotionWebView.setWebViewClickListener(l);
+        }
+    }
+
+    public void destroy() {
+        if (promotionWebView != null) {
+            promotionWebView.destroyWebView();
+            promotionWebView = null;
         }
     }
 }

--- a/affirm/src/main/java/com/affirm/android/AffirmTrackView.java
+++ b/affirm/src/main/java/com/affirm/android/AffirmTrackView.java
@@ -1,12 +1,10 @@
 package com.affirm.android;
 
 import android.annotation.SuppressLint;
-import android.app.Activity;
 import android.content.Context;
 import android.os.Build;
 import android.os.Handler;
 import android.view.View;
-import android.view.ViewGroup;
 import android.webkit.CookieManager;
 import android.widget.FrameLayout;
 
@@ -128,17 +126,7 @@ public class AffirmTrackView extends FrameLayout
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
         AffirmLog.v("AffirmTrackView detached from window");
-        Context context = getContext();
-        if (context != null) {
-            ViewGroup container =
-                    ((Activity) context).getWindow()
-                            .getDecorView().findViewById(android.R.id.content);
-            container.removeView(webView);
-        }
-        webView.removeAllViews();
-        webView.destroyDrawingCache();
-        webView.clearHistory();
-        webView.destroy();
+        webView.destroyWebView();
         webView = null;
         handler.removeCallbacksAndMessages(null);
     }

--- a/affirm/src/main/java/com/affirm/android/AffirmUtils.java
+++ b/affirm/src/main/java/com/affirm/android/AffirmUtils.java
@@ -52,6 +52,8 @@ public final class AffirmUtils {
             total.append(line).append('\n');
         }
 
+        inputStream.close();
+        r.close();
         return total.toString();
     }
 

--- a/affirm/src/main/java/com/affirm/android/AffirmWebView.java
+++ b/affirm/src/main/java/com/affirm/android/AffirmWebView.java
@@ -3,6 +3,7 @@ package com.affirm.android;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.util.AttributeSet;
+import android.view.ViewGroup;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 
@@ -26,5 +27,17 @@ class AffirmWebView extends WebView {
         getSettings().setSupportMultipleWindows(true);
         getSettings().setCacheMode(WebSettings.LOAD_NO_CACHE);
         setVerticalScrollBarEnabled(false);
+    }
+
+    protected void destroyWebView() {
+        if (getParent() != null) {
+            ViewGroup viewGroup = (ViewGroup) getParent();
+            viewGroup.removeAllViews();
+        }
+        removeAllViews();
+        clearCache(true);
+        destroyDrawingCache();
+        clearHistory();
+        destroy();
     }
 }

--- a/affirm/src/main/java/com/affirm/android/AffirmWebViewClient.java
+++ b/affirm/src/main/java/com/affirm/android/AffirmWebViewClient.java
@@ -2,12 +2,15 @@ package com.affirm.android;
 
 import android.annotation.TargetApi;
 import android.os.Build;
+import android.webkit.RenderProcessGoneDetail;
 import android.webkit.WebResourceError;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 
 import com.affirm.android.exception.ConnectionException;
 
@@ -55,6 +58,18 @@ abstract class AffirmWebViewClient extends WebViewClient {
             callbacks.onWebViewError(new ConnectionException(
                     error.getErrorCode() + ", " + error.getDescription().toString()));
         }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    @Override
+    public boolean onRenderProcessGone(@Nullable final WebView view,
+                                       @Nullable final RenderProcessGoneDetail detail) {
+        final String errorMessage = detail != null && detail.didCrash()
+                ? "Render process for this WebView has crashed."
+                : "Render process is gone for this WebView. Unspecified cause.";
+        AffirmLog.e(errorMessage);
+        callbacks.onWebViewError(new ConnectionException(errorMessage));
+        return true;
     }
 
     public interface WebViewClientCallbacks {


### PR DESCRIPTION
- Handle `WebViewClient#onRenderProcessGone` for API 26+ devices so WebView crashes do not take the entire process with it.
- close inputStream that needed
- clean AffirmPromotionButton to avoid create an unused webview
- Destroy promo webview when host activity destroy