### PR TITLE
fix: Add CardBillingAddress to CardDetails for correct JSON deserialization

### DIFF
--- a/affirm/src/main/java/com/affirm/android/model/CardBillingAddress.java
+++ b/affirm/src/main/java/com/affirm/android/model/CardBillingAddress.java
@@ -1,0 +1,57 @@
+package com.affirm.android.model;
+
+import android.os.Parcelable;
+
+import androidx.annotation.Nullable;
+
+import com.google.auto.value.AutoValue;
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.SerializedName;
+
+@AutoValue
+public abstract class CardBillingAddress implements Parcelable {
+
+    public static CardBillingAddress.Builder builder() {
+        return new AutoValue_CardBillingAddress.Builder();
+    }
+
+    public static TypeAdapter<CardBillingAddress> typeAdapter(Gson gson) {
+        return new AutoValue_CardBillingAddress.GsonTypeAdapter(gson);
+    }
+
+    @Nullable
+    @SerializedName("line1")
+    public abstract String line1();
+
+    @Nullable
+    @SerializedName("line2")
+    public abstract String line2();
+
+    @Nullable
+    @SerializedName("city")
+    public abstract String city();
+
+    @Nullable
+    @SerializedName("state")
+    public abstract String state();
+
+    @Nullable
+    @SerializedName("zipcode")
+    public abstract String zipcode();
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+        public abstract Builder setLine1(String value);
+
+        public abstract Builder setLine2(String value);
+
+        public abstract Builder setCity(String value);
+
+        public abstract Builder setState(String value);
+
+        public abstract Builder setZipcode(String value);
+
+        public abstract CardBillingAddress build();
+    }
+}

--- a/affirm/src/main/java/com/affirm/android/model/CardDetails.java
+++ b/affirm/src/main/java/com/affirm/android/model/CardDetails.java
@@ -46,6 +46,10 @@ public abstract class CardDetails implements Parcelable {
     @SerializedName("id")
     public abstract String id();
 
+    @Nullable
+    @SerializedName("billing_address")
+    public abstract CardBillingAddress billingAddress();
+
     @AutoValue.Builder
     public abstract static class Builder {
         public abstract CardDetails.Builder setCardholderName(String value);
@@ -61,6 +65,8 @@ public abstract class CardDetails implements Parcelable {
         public abstract CardDetails.Builder setCallbackId(String value);
 
         public abstract CardDetails.Builder setId(String value);
+
+        public abstract CardDetails.Builder setBillingAddress(CardBillingAddress value);
 
         public abstract CardDetails build();
     }

--- a/affirm/src/test/java/com/affirm/android/VcnCheckoutWebViewClientTest.java
+++ b/affirm/src/test/java/com/affirm/android/VcnCheckoutWebViewClientTest.java
@@ -7,6 +7,7 @@ import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
 
 import com.affirm.android.exception.ConnectionException;
+import com.affirm.android.model.CardBillingAddress;
 import com.affirm.android.model.CardDetails;
 import com.affirm.android.model.VcnReason;
 import com.google.gson.Gson;
@@ -77,6 +78,36 @@ public class VcnCheckoutWebViewClientTest {
                 .setCallbackId("031efdda-b6ed-4593-8da4-8889306d60bb")
                 .setId("S4FIKFJHE0HQBGRL")
                 .build();
+        Mockito.verify(callbacks).onWebViewConfirmation(expected);
+    }
+
+    @Test
+    public void shouldOverrideUrlLoading_ConfirmationWithBilling() {
+        final String encodedData =
+                "%7B%22checkout_token%22%3A%22TVY2I3JVYCW0FWYF%22%2C%22cvv%22%3A%22123%22%2C%22number%22%3A%224111111111111111%22%2C%22cardholder_name%22%3A%22AffirmInc%20John%20R%20Andrew%22%2C%22expiration%22%3A%220423%22%2C%22callback_id%22%3A%22cd5d5440-3d63-4e4c-9aa2-fbf16ea689e6%22%2C%22id%22%3A%22TVY2I3JVYCW0FWYF%22%2C%22billing_address%22%3A%7B%22line1%22%3A%22650%20California%20St.%22%2C%22line2%22%3A%2212th%20Floor%22%2C%22city%22%3A%22San%20Francisco%22%2C%22state%22%3A%22CA%22%2C%22zipcode%22%3A%2294108%22%7D%7D";
+
+        affirmWebViewClient.shouldOverrideUrlLoading(webview,
+                "affirm://checkout/confirmed?data=" + encodedData);
+
+        final CardBillingAddress billingAddress = CardBillingAddress.builder()
+                .setLine1("650 California St.")
+                .setLine2("12th Floor")
+                .setCity("San Francisco")
+                .setState("CA")
+                .setZipcode("94108")
+                .build();
+
+        final CardDetails expected = CardDetails.builder()
+                .setCheckoutToken("TVY2I3JVYCW0FWYF")
+                .setCvv("123")
+                .setNumber("4111111111111111")
+                .setCardholderName("AffirmInc John R Andrew")
+                .setExpiration("0423")
+                .setCallbackId("cd5d5440-3d63-4e4c-9aa2-fbf16ea689e6")
+                .setId("TVY2I3JVYCW0FWYF")
+                .setBillingAddress(billingAddress)
+                .build();
+
         Mockito.verify(callbacks).onWebViewConfirmation(expected);
     }
 


### PR DESCRIPTION
fix: deserialize billing address in CardDetails JSON

- Added CardBillingAddress class to represent billing address fields
- Ensured Gson can correctly parse JSON containing billing_address into the CardDetails object