### PR TITLE
fix: allow re-initialization to update SDK config for region switching

### DIFF
--- a/affirm/src/main/java/com/affirm/android/Affirm.java
+++ b/affirm/src/main/java/com/affirm/android/Affirm.java
@@ -558,7 +558,8 @@ public final class Affirm {
         AffirmUtils.requireNonNull(configuration, "configuration cannot be null");
 
         if (isInitialized()) {
-            AffirmLog.w("Affirm is already initialized");
+            AffirmLog.d("Affirm is already initialized, updating configuration");
+            AffirmPlugins.get().setConfiguration(configuration);
             return;
         }
         AffirmPlugins.initialize(configuration);

--- a/affirm/src/test/java/com/affirm/android/AffirmTest.java
+++ b/affirm/src/test/java/com/affirm/android/AffirmTest.java
@@ -54,6 +54,46 @@ public class AffirmTest {
     }
 
     @Test
+    public void testReInitializeUpdatesConfiguration() {
+        // Re-initialize with CA configuration
+        Affirm.initialize(new Affirm.Configuration.Builder("CA_KEY", Affirm.Environment.SANDBOX)
+                .setLocale("en_CA")
+                .setCountryCode("CAN")
+                .build()
+        );
+        assertEquals("en_CA", AffirmPlugins.get().locale());
+        assertEquals("CAN", AffirmPlugins.get().countryCode());
+        assertEquals("CA_KEY", AffirmPlugins.get().publicKey());
+
+        // Re-initialize with UK configuration (should update, not be silently ignored)
+        Affirm.initialize(new Affirm.Configuration.Builder("UK_KEY", Affirm.Environment.SANDBOX)
+                .setLocale("en_GB")
+                .setCountryCode("GBR")
+                .build()
+        );
+        assertEquals("en_GB", AffirmPlugins.get().locale());
+        assertEquals("GBR", AffirmPlugins.get().countryCode());
+        assertEquals("UK_KEY", AffirmPlugins.get().publicKey());
+    }
+
+    @Test
+    public void testRegionSwitchCAtoUK() {
+        // Initialize with CA
+        Affirm.initialize(new Affirm.Configuration.Builder("CA_KEY", Affirm.Environment.SANDBOX)
+                .setLocale("en_CA")
+                .setCountryCode("CAN")
+                .build()
+        );
+
+        // Switch to UK using setters
+        Affirm.setLocale("en_GB");
+        Affirm.setCountryCode("GBR");
+
+        assertEquals("en_GB", AffirmPlugins.get().locale());
+        assertEquals("GBR", AffirmPlugins.get().countryCode());
+    }
+
+    @Test
     public void onActivityResult_Success() {
         Affirm.CheckoutCallbacks callbacks = Mockito.mock(Affirm.CheckoutCallbacks.class);
 


### PR DESCRIPTION
## Summary
- Changes Affirm.initialize() to update configuration when called again instead of silently ignoring re-initialization
- Enables merchants to switch regions (e.g., CA to UK) by calling initialize() with new configuration

## Problem
When a merchant app switches shipping address from Canada (CAD) to UK (GBP) within the same session, the SDK meta.locale field remains set to en_CA. This causes checkout failures with: currency GBP is not supported for country CAN.

Root cause: Affirm.initialize() silently returned when called a second time, discarding the new configuration with updated locale/countryCode.

## Solution
Changed initialize() to update the existing configuration via AffirmPlugins.get().setConfiguration() when the SDK is already initialized, instead of silently discarding the new configuration.

Merchants can now switch regions by either:
1. Re-initializing with new configuration (now works)
2. Using individual setters: Affirm.setLocale() and Affirm.setCountryCode() (already worked)

## Test plan
- [ ] Verify calling initialize() twice with different locale/countryCode updates the configuration
- [ ] Verify checkout requests after re-initialization use the new locale in meta.locale and headers
- [ ] Verify switching from CA config to UK config mid-session works
- [ ] Verify initial initialize() call still works as before
- [ ] Verify setLocale() and setCountryCode() individual setters still work